### PR TITLE
Fixed typo

### DIFF
--- a/source/ui/menu.c
+++ b/source/ui/menu.c
@@ -453,7 +453,7 @@ uint8_t handle_input(void)
 
     if (input.down & KEY_B)
     {
-        if (ui_display_yes_no_box("would you like to exit?"))
+        if (ui_display_yes_no_box("Would you like to exit?"))
             return Option_Exit;  
     }
 


### PR DESCRIPTION
When you exit by pressing B, the `W` in would isn't capitalized, sorry I just had to and couldn't resist...